### PR TITLE
Add Eta template engine middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,46 @@ app.use(responseTimeHeader);
 await app.listen(":80");
 ```
 
+### Template Rendering
+
+#### `etaEngine`
+
+Middleware that allows Oak to work with the [Eta](https://eta.js.org) template engine, an embedded JavaScript template engine similar to EJS. 
+
+```ts
+// app.ts
+import { Application } from "https://deno.land/x/oak/mod.ts"
+import * as path from "https://deno.land/std/path/mod.ts"
+import { etaEngine } from "https://deno.land/x/oak-middleware/mod.ts"
+
+const __dirname = new URL(".", import.meta.url).pathname
+
+const app = new Application()
+
+app.use(
+  etaEngine({
+    views: path.join(__dirname, "views"),
+    cache: false
+  })
+)
+
+app.use((ctx) => {
+  ctx.render("template", {
+    favorite: "cake",
+    number: Math.floor(Math.random() * 100) + 1
+  })
+})
+
+await app.listen({ port: 8000 })
+```
+
+```html
+<% /* views/template.eta */ %>
+<b>My favorite food is <%= it.favorite %></b>
+```
+
+See [./eta-template/example.ts](./eta-template/example.ts) for a more complete example.
+
 ## Router Middleware
 
 This section contains middleware designed to work with the oak `Router`.

--- a/eta-template/example.ts
+++ b/eta-template/example.ts
@@ -1,0 +1,25 @@
+import { Application } from "https://deno.land/x/oak@v6.1.0/mod.ts"
+import * as path from "https://deno.land/std@0.66.0/path/mod.ts"
+import { etaEngine } from "./mod.ts"
+
+const __dirname = new URL(".", import.meta.url).pathname
+
+const app = new Application()
+
+app.use(
+  etaEngine({
+    views: path.join(__dirname, "views"),
+    cache: false
+  })
+)
+
+app.use((ctx) => {
+  ctx.render("template", {
+    favorite: "cake",
+    number: Math.floor(Math.random() * 100) + 1
+  })
+})
+
+console.log("Listening on http://localhost:8000")
+
+await app.listen({ port: 8000 })

--- a/eta-template/example.ts
+++ b/eta-template/example.ts
@@ -1,6 +1,12 @@
-import { Application } from "https://deno.land/x/oak@v6.1.0/mod.ts"
+import { Application } from "https://deno.land/x/oak@v6.2.0/mod.ts"
 import * as path from "https://deno.land/std@0.66.0/path/mod.ts"
 import { etaEngine } from "./mod.ts"
+
+declare module "https://deno.land/x/oak@v6.2.0/mod.ts" {
+  interface Context {
+    render: (fileName: string, data?: object) => void
+  }
+}
 
 const __dirname = new URL(".", import.meta.url).pathname
 

--- a/eta-template/mod.ts
+++ b/eta-template/mod.ts
@@ -1,0 +1,32 @@
+import { renderFile } from "https://deno.land/x/eta@v1.7.0/mod.ts"
+
+import type { Context } from "https://deno.land/x/oak@v6.1.0/mod.ts"
+
+// TODO: this only works if the user is using the latest version of Oak
+declare module "https://deno.land/x/oak/mod.ts" {
+  interface Context {
+    render: (fileName: string, data?: object) => void
+  }
+
+  interface RouterContext {
+    render: (fileName: string, data?: object) => void
+  }
+}
+
+export function etaEngine(opts: object) {
+  return async function (ctx: Context, next: Function) {
+    ctx.render = async function (filepath: string, data?: object) {
+      try {
+        ctx.response.type = "html"
+        ctx.response.headers.set("Content-Type", "text/html; charset=utf-8")
+
+        ctx.response.body = await renderFile(filepath, data || {}, opts)
+      } catch (e) {
+        ctx.response.status = 404
+        console.log(e.message)
+      }
+    }
+
+    await next()
+  }
+}

--- a/eta-template/mod.ts
+++ b/eta-template/mod.ts
@@ -1,31 +1,20 @@
-import { renderFile } from "https://deno.land/x/eta@v1.7.0/mod.ts"
-
-import type { Context } from "https://deno.land/x/oak@v6.1.0/mod.ts"
-
-// TODO: this only works if the user is using the latest version of Oak
-declare module "https://deno.land/x/oak/mod.ts" {
-  interface Context {
-    render: (fileName: string, data?: object) => void
-  }
-
-  interface RouterContext {
-    render: (fileName: string, data?: object) => void
-  }
-}
+import { renderFile } from "https://deno.land/x/eta@v1.11.0/mod.ts"
 
 export function etaEngine(opts: object) {
-  return async function (ctx: Context, next: Function) {
-    ctx.render = async function (filepath: string, data?: object) {
-      try {
-        ctx.response.type = "html"
-        ctx.response.headers.set("Content-Type", "text/html; charset=utf-8")
+  return async function (ctx: any, next: Function) {
+    Object.assign(ctx, {
+      render: async function (filepath: string, data?: object) {
+        try {
+          ctx.response.type = "html"
+          ctx.response.headers.set("Content-Type", "text/html; charset=utf-8")
 
-        ctx.response.body = await renderFile(filepath, data || {}, opts)
-      } catch (e) {
-        ctx.response.status = 404
-        console.log(e.message)
+          ctx.response.body = await renderFile(filepath, data || {}, opts)
+        } catch (e) {
+          ctx.response.status = 404
+          console.log(e.message)
+        }
       }
-    }
+    })
 
     await next()
   }

--- a/eta-template/views/footer.eta
+++ b/eta-template/views/footer.eta
@@ -1,0 +1,4 @@
+<br /><br />
+<footer style="font-weight: bold">
+  This is a footer included from a partial file
+</footer>

--- a/eta-template/views/template.eta
+++ b/eta-template/views/template.eta
@@ -1,0 +1,5 @@
+<h1>This was rendered from a template!</h1>
+
+My favorite food is <%= it.favorite %>, and my favorite number is <%= it.number %>
+
+<%~ includeFile('./footer') %>

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,4 @@
 // Copyright 2020 the oak authors. All rights reserved. MIT license.
 
 export { responseTimeHeader } from "./observability/response_time_header.ts";
+export { etaEngine } from "./eta-template/mod.ts";


### PR DESCRIPTION
As discussed in https://github.com/oakserver/middleware/issues/5, this PR adds middleware that enables template rendering with [Eta](https://eta.js.org) :rocket:

The middleware works well, but there's one problem. Inside the middleware file, I write

```ts
declare module "https://deno.land/x/oak/mod.ts" {
  interface Context {
    render: (fileName: string, data?: object) => void
  }

  interface RouterContext {
    render: (fileName: string, data?: object) => void
  }
}
```

To add the `.render` method to the `Context` type (based on the [view_engine](https://github.com/deligenius/view-engine) middleware). However, this only works if the user is using the same version of Oak; in this case, the latest version. Any thoughts?

I'm open to any feedback or requested changes :smiley: 