### PR TITLE
Adding in middleware for enabling websockets.

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,4 @@
 // Copyright 2020 the oak authors. All rights reserved. MIT license.
 
 export { responseTimeHeader } from "./observability/response_time_header.ts";
+export { WebSocketMiddleware } from "./websocket/enable_websockets.ts";

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -1,0 +1,49 @@
+The following is a re-implementation of the example server in [std/ws](https://deno.land/std@0.76.0/ws):
+
+```ts
+import { WebSocketMiddleware } from "https://deno.land/x/oak-middleware/mod.ts";
+import { Application } from "https://deno.land/x/oak/mod.ts";
+import {
+  isWebSocketCloseEvent,
+  isWebSocketPingEvent,
+  WebSocket,
+} from "https://deno.land/std@0.76.0/ws/mod.ts";
+
+async function handleWs(sock: WebSocket) {
+  console.log("socket connected!");
+  try {
+    for await (const ev of sock) {
+      if (typeof ev === "string") {
+        // text message.
+        console.log("ws:Text", ev);
+        await sock.send(ev);
+      } else if (ev instanceof Uint8Array) {
+        // binary message.
+        console.log("ws:Binary", ev);
+      } else if (isWebSocketPingEvent(ev)) {
+        const [, body] = ev;
+        // ping.
+        console.log("ws:Ping", body);
+      } else if (isWebSocketCloseEvent(ev)) {
+        // close.
+        const { code, reason } = ev;
+        console.log("ws:Close", code, reason);
+      }
+    }
+  } catch (err) {
+    console.error(`failed to receive frame: ${err}`);
+
+    if (!sock.isClosed) {
+      await sock.close(1000).catch(console.error);
+    }
+  }
+}
+
+const app = new App();
+app.use(WebSocketMiddleware(handleWs));
+
+// other middleware
+
+await app.listen(":80");
+
+```

--- a/websocket/enable_websockets.ts
+++ b/websocket/enable_websockets.ts
@@ -1,8 +1,8 @@
 import type { Middleware, Context } from "https://deno.land/x/oak@v6.3.1/mod.ts";
 import { WebSocket, acceptable } from 'https://deno.land/std@0.76.0/ws/mod.ts'
-export type WebsocketHandler = (socket: WebSocket, url: URL, headers: Headers) => Promise<void>;
+export type WebSocketHandler = (socket: WebSocket, url: URL, headers: Headers) => Promise<void>;
 
-export function WebSocketMiddleware(handler: WebsocketHandler){
+export function WebSocketMiddleware(handler: WebSocketHandler){
     return async function real_middleware(ctx: Context, next: () => Promise<void>) {
             if(acceptable(ctx.request)) {
             let ws = await ctx.upgrade();

--- a/websocket/enable_websockets.ts
+++ b/websocket/enable_websockets.ts
@@ -1,0 +1,23 @@
+import type { Middleware, Context } from "https://deno.land/x/oak@v6.3.1/mod.ts";
+import { WebSocket, acceptable } from 'https://deno.land/std@0.76.0/ws/mod.ts'
+export type handler = (socket: WebSocket, url: URL, headers: Headers) => Promise<void>;
+export class WebSocketMiddleware {
+    public handler: handler;
+
+    constructor(handler: handler) {
+        this.handler = handler;
+    }
+
+    private async real_middleware(ctx: Context, next: () => Promise<void>) {
+        if (acceptable(ctx.request)) {
+            let ws = await ctx.upgrade();
+            await this.handler(ws, ctx.request.url, ctx.request.headers);
+        } else {
+            return await next();
+        }
+    }
+
+    public middleware(): Middleware {
+        return async (ctx, next) => { await this.real_middleware(ctx, next) };
+    }
+}

--- a/websocket/enable_websockets.ts
+++ b/websocket/enable_websockets.ts
@@ -1,23 +1,14 @@
 import type { Middleware, Context } from "https://deno.land/x/oak@v6.3.1/mod.ts";
 import { WebSocket, acceptable } from 'https://deno.land/std@0.76.0/ws/mod.ts'
-export type handler = (socket: WebSocket, url: URL, headers: Headers) => Promise<void>;
-export class WebSocketMiddleware {
-    public handler: handler;
+export type WebsocketHandler = (socket: WebSocket, url: URL, headers: Headers) => Promise<void>;
 
-    constructor(handler: handler) {
-        this.handler = handler;
-    }
-
-    private async real_middleware(ctx: Context, next: () => Promise<void>) {
-        if (acceptable(ctx.request)) {
+export function WebSocketMiddleware(handler: WebsocketHandler){
+    return async function real_middleware(ctx: Context, next: () => Promise<void>) {
+            if(acceptable(ctx.request)) {
             let ws = await ctx.upgrade();
-            await this.handler(ws, ctx.request.url, ctx.request.headers);
+            await handler(ws, ctx.request.url, ctx.request.headers);
         } else {
             return await next();
         }
-    }
-
-    public middleware(): Middleware {
-        return async (ctx, next) => { await this.real_middleware(ctx, next) };
-    }
+    };
 }


### PR DESCRIPTION
It should not take a week to figure out how to set up WebSockets with oak.

This is the idiot's websocket module. Mostly for documentation but it is useful for prototyping.

I don't have a test case for it yet. I don't know how to write one.